### PR TITLE
✨ Feat: 특정 카테고리 API 삭제 구현

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/category/controller/CategoryController.java
+++ b/src/main/java/com/hanghae/bulletbox/category/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.hanghae.bulletbox.category.controller;
 import com.hanghae.bulletbox.category.dto.CategoryDto;
 import com.hanghae.bulletbox.category.dto.RequestCreateCategoryDto;
 import com.hanghae.bulletbox.category.dto.RequestUpdateCategoryDto;
+import com.hanghae.bulletbox.category.dto.ResponseDeleteCategoryDto;
 import com.hanghae.bulletbox.category.dto.ResponseShowCategoryDto;
 import com.hanghae.bulletbox.category.service.CategoryPageService;
 import com.hanghae.bulletbox.common.response.Response;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -87,5 +89,22 @@ public class CategoryController {
         categoryService.updateCategory(categoryDto);
 
         return Response.success(200, "카테고리 수정을 성공했습니다.", null);
+    }
+
+    @Operation(tags = {"Category"}, summary = "카테고리 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리 삭제를 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 카테고리입니다.")
+    })
+    @DeleteMapping("/{categoryId}")
+    public Response deleteCategory(@PathVariable Long categoryId,
+                                   @ApiIgnore @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Member member = userDetails.getMember();
+
+        CategoryDto categoryDto = CategoryDto.toCategoryDto(member, categoryId);
+        ResponseDeleteCategoryDto responseDeleteCategoryDto = categoryService.deleteCategory(categoryDto);
+
+        return Response.success(200, "카테고리 삭제를 성공했습니다.", responseDeleteCategoryDto);
     }
 }

--- a/src/main/java/com/hanghae/bulletbox/category/dto/CategoryDto.java
+++ b/src/main/java/com/hanghae/bulletbox/category/dto/CategoryDto.java
@@ -74,4 +74,11 @@ public class CategoryDto {
                 .categoryColor(categoryColor)
                 .build();
     }
+
+    public static CategoryDto toCategoryDto(Member member, Long categoryId) {
+        return CategoryDto.builder()
+                .member(member)
+                .categoryId(categoryId)
+                .build();
+    }
 }

--- a/src/main/java/com/hanghae/bulletbox/category/dto/ResponseDeleteCategoryDto.java
+++ b/src/main/java/com/hanghae/bulletbox/category/dto/ResponseDeleteCategoryDto.java
@@ -1,0 +1,27 @@
+package com.hanghae.bulletbox.category.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(name = "ResponseDeleteCategoryDto", description = "카테고리 삭제 응답 DTO")
+public class ResponseDeleteCategoryDto {
+
+    @Schema(description = "카테고리 id", example = "1", type = "Long")
+    private Long categoryId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ResponseDeleteCategoryDto(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public static ResponseDeleteCategoryDto toResponseDeleteCategoryDto(Long categoryId) {
+        return ResponseDeleteCategoryDto.builder()
+                .categoryId(categoryId)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/bulletbox/category/service/CategoryPageService.java
+++ b/src/main/java/com/hanghae/bulletbox/category/service/CategoryPageService.java
@@ -1,6 +1,7 @@
 package com.hanghae.bulletbox.category.service;
 
 import com.hanghae.bulletbox.category.dto.CategoryDto;
+import com.hanghae.bulletbox.category.dto.ResponseDeleteCategoryDto;
 import com.hanghae.bulletbox.category.dto.ResponseShowCategoryDto;
 import com.hanghae.bulletbox.category.entity.Category;
 import com.hanghae.bulletbox.category.repository.CategoryRepository;
@@ -83,5 +84,22 @@ public class CategoryPageService {
         String categoryColor = categoryDto.getCategoryColor();
 
         category.update(categoryName, categoryColor);
+    }
+
+    @Transactional
+    public ResponseDeleteCategoryDto deleteCategory(CategoryDto categoryDto) {
+
+        // 카테고리 존재 여부 확인
+        Member member = categoryDto.getMember();
+        Long categoryId = categoryDto.getCategoryId();
+
+        Category category = categoryRepository.findAllByMemberAndCategoryId(member, categoryId).orElseThrow(
+                () -> new IllegalArgumentException(NOT_FOUND_CATEGORY_MSG.getMsg())
+        );
+
+        // 카테고리 삭제
+        categoryRepository.delete(category);
+
+        return ResponseDeleteCategoryDto.toResponseDeleteCategoryDto(categoryId);
     }
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
특정 카테고리 API 삭제 구현

## 작업사항
- 특정 카테고리 삭제 API 컨트롤러에 추가
- CategoryDto 카테고리 서비스 범용 DTO에 member, categoryId 를 파라미터로 받는 정적 팩토리 메서드 추가
- ResponseDeleteCategoryDto 특정 카테고리 삭제 API 응답 DTO 생성
- 특정 카테고리 삭제 API 서비스 로직 구현

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #86 

## 스크린샷
<img width="990" alt="image" src="https://user-images.githubusercontent.com/105099062/212962088-1b8bfe8d-cc3f-489b-ae88-bbdbdbdd2836.png">


