### PR TITLE
🐛 Fix: 메인 페이지 조회 시 오류 발생

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/diary/controller/MainController.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/controller/MainController.java
@@ -4,7 +4,6 @@ import com.hanghae.bulletbox.common.response.Response;
 import com.hanghae.bulletbox.common.security.UserDetailsImpl;
 import com.hanghae.bulletbox.diary.dto.ResponseShowCalendarDto;
 import com.hanghae.bulletbox.diary.dto.ResponseShowMainPageDto;
-import com.hanghae.bulletbox.diary.dto.ResponseShowDailyByCategoryDto;
 import com.hanghae.bulletbox.diary.dto.ResponseShowDailyDto;
 import com.hanghae.bulletbox.diary.service.MainService;
 import com.hanghae.bulletbox.member.dto.MemberDto;
@@ -18,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -74,22 +72,5 @@ public class MainController {
         TodoDto todoDto = TodoDto.toTodoDto(memberDto, year, month, day);
         ResponseShowDailyDto responseShowDailyDto = mainService.showDaily(todoDto);
         return Response.success(200, "데일리 로그 날짜 변경 조회를 성공했습니다.", responseShowDailyDto);
-    }
-
-    @Operation(tags = {"Main"}, summary = "카테고리별 데일리 로그 조회를 성공했습니다.", responses = {
-            @ApiResponse(responseCode = "200", description = "카테고리별 데일리 로그 조회를 성공했습니다."),
-            @ApiResponse(responseCode = "400", description = "존재하지 않는 사용자입니다.")
-    })
-    @GetMapping("/dailys/{categoryId}")
-    public Response<ResponseShowDailyByCategoryDto> showDailyByCategory(@PathVariable Long categoryId,
-                                                                        @RequestParam(value = "year") Long year,
-                                                                        @RequestParam(value = "month") Long month,
-                                                                        @RequestParam(value = "day") Long day,
-                                                                        @ApiIgnore @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        MemberDto memberDto = MemberDto.toMemberDto(userDetails);
-        TodoDto todoDto = TodoDto.toTodoDto(memberDto, categoryId, year, month, day);
-        ResponseShowDailyByCategoryDto responseShowDailyByCategoryDto = mainService.showDailyByCategory(todoDto);
-        return Response.success(200, "카테고리별 데일리 로그 조회를 성공했습니다.", responseShowDailyByCategoryDto);
     }
 }

--- a/src/main/java/com/hanghae/bulletbox/diary/dto/DailyDto.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/dto/DailyDto.java
@@ -6,6 +6,7 @@ import com.hanghae.bulletbox.todo.entity.Todo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,6 +41,7 @@ public class DailyDto {
     @Schema(description = "할 일의 하위 메모")
     private List<TodoMemo> todoMemos;
 
+    @Builder(access = AccessLevel.PRIVATE)
     private DailyDto(Long todoId, Long categoryId, String categoryColor, String todoBulletName, String todoBulletImgUrl, String todoContent, String time, List<TodoMemo> todoMemos) {
         this.todoId = todoId;
         this.categoryId = categoryId;

--- a/src/main/java/com/hanghae/bulletbox/diary/service/DailyService.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/service/DailyService.java
@@ -60,11 +60,12 @@ public class DailyService {
         Long todoDay = (long) LocalDate.now().getDayOfMonth();
         List<Todo> todoList = todoRepository.findAllByMemberAndTodoYearAndTodoMonthAndTodoDay(member, todoYear, todoMonth, todoDay);
 
-        List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMember(member);
         for (Todo todo : todoList) {
+            List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMemberAndTodo(member, todo);
             for (TodoMemo todoMemo : todoMemoList) {
                 if (todoMemo.getTodo().equals(todo)) {
                     dailyDtoList.add(DailyDto.toDailyDto(todo, todoMemoList));
+                    break;
                 }
             }
         }
@@ -81,15 +82,17 @@ public class DailyService {
         Long todoMonth = todoDto.getTodoMonth();
         Long todoDay = todoDto.getTodoDay();
         List<Todo> todoList = todoRepository.findAllByMemberAndTodoYearAndTodoMonthAndTodoDay(member, todoYear, todoMonth, todoDay);
-        List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMember(member);
 
         for (Todo todo : todoList) {
+            List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMemberAndTodo(member, todo);
             for (TodoMemo todoMemo : todoMemoList) {
                 if (todoMemo.getTodo().equals(todo)) {
                     dailyDtoList.add(DailyDto.toDailyDto(todo, todoMemoList));
+                    break;
                 }
             }
         }
+
         return ResponseShowDailyDto.toResponseShowDailyDto(dailyDtoList);
     }
 
@@ -104,11 +107,12 @@ public class DailyService {
         Long todoDay = todoDto.getTodoDay();
         List<Todo> todoList = todoRepository.findAllByMemberAndCategoryIdAndTodoYearAndTodoMonthAndTodoDay(member, categoryId, todoYear, todoMonth, todoDay);
 
-        List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMember(member);
         for (Todo todo : todoList) {
+            List<TodoMemo> todoMemoList = todoMemoRepository.findAllByMemberAndTodo(member, todo);
             for (TodoMemo todoMemo : todoMemoList) {
                 if (todoMemo.getTodo().equals(todo)) {
                     dailyDtoList.add(DailyDto.toDailyDto(todo, todoMemoList));
+                    break;
                 }
             }
         }

--- a/src/main/java/com/hanghae/bulletbox/todo/repository/TodoMemoRepository.java
+++ b/src/main/java/com/hanghae/bulletbox/todo/repository/TodoMemoRepository.java
@@ -1,6 +1,7 @@
 package com.hanghae.bulletbox.todo.repository;
 
 import com.hanghae.bulletbox.member.entity.Member;
+import com.hanghae.bulletbox.todo.entity.Todo;
 import com.hanghae.bulletbox.todo.entity.TodoMemo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface TodoMemoRepository extends JpaRepository<TodoMemo, Long> {
 
     List<TodoMemo> findAllByMember(Member member);
+
+    List<TodoMemo> findAllByMemberAndTodo(Member member, Todo todo);
 }

--- a/src/main/java/com/hanghae/bulletbox/todo/repository/TodoRepository.java
+++ b/src/main/java/com/hanghae/bulletbox/todo/repository/TodoRepository.java
@@ -14,5 +14,4 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findAllByMemberAndTodoYearAndTodoMonthAndTodoDay(Member member, Long todoYear, Long todoMonth, Long todoDay);
 
     List<Todo> findAllByMemberAndCategoryIdAndTodoYearAndTodoMonthAndTodoDay(Member member, Long categoryId, Long todoYear, Long todoMonth, Long todoDay);
-
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
메인 페이지 조회 시 오류 발생

## 작업사항
- 메인 페이지 조회 시, 할 일에 메모의 개수만큼 할 일이 출력되는 오류 발생.
- 오류 발생하는 로직을 사용하는 서비스 로직을 모두 수정.

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #101 

## 스크린샷
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/105099062/213521469-339a0aad-8ebd-44b8-97c5-ac7c33dcd9a3.png">
메인 페이지 조회는 할 일이 현재 날짜를 조회하기 때문에 현재 날짜의 데이터가 존재하지 않아 빈 값으로 나타남.
