### PR TITLE
🐛 Fix: 메인 페이지 조회 시 달력 내 할 일의 요일과 개수가 출력되지 않는 오류 발생

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/BulletBoxApplication.java
+++ b/src/main/java/com/hanghae/bulletbox/BulletBoxApplication.java
@@ -4,12 +4,20 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+
+import java.util.TimeZone;
+
 @EnableJpaAuditing
 @SpringBootApplication
 public class BulletBoxApplication {
 
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(BulletBoxApplication.class, args);
     }
-
 }

--- a/src/main/java/com/hanghae/bulletbox/diary/dto/ResponseShowCalendarDto.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/dto/ResponseShowCalendarDto.java
@@ -3,6 +3,7 @@ package com.hanghae.bulletbox.diary.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,11 +17,14 @@ public class ResponseShowCalendarDto {
     @Schema(description = "매인 페이지 달력의 정보")
     private List<CalendarDto> calendar;
 
+    @Builder(access = AccessLevel.PRIVATE)
     private ResponseShowCalendarDto(List<CalendarDto> calendarDtoList) {
         this.calendar = calendarDtoList;
     }
 
     public static ResponseShowCalendarDto toResponseChangeCalendarDto(List<CalendarDto> calendarDtoList) {
-        return new ResponseShowCalendarDto(calendarDtoList);
+        return ResponseShowCalendarDto.builder()
+                .calendarDtoList(calendarDtoList)
+                .build();
     }
 }

--- a/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
@@ -74,24 +74,29 @@ public class MainService {
 
         // calendar 정보 가져오기
         // 메인 페이지 달력에서 일별 할 일의 개수를 세는 로직
+        todoList = todoRepository.findAllByMemberAndTodoYearAndTodoMonth(member, todoYear, todoMonth);
+
         Map<Long, Long> countTodoPerDayMap = new HashMap<>();
         List<CalendarDto> calendarDtoList = new ArrayList<>();
 
         for (Todo todo : todoList) {
             Long day = todo.getTodoDay();
-            Long count;
             boolean isContainsKeyOfDay = countTodoPerDayMap.containsKey(day);
 
             // Map 의 key 값에 day 가 존재하는 지에 따라 구분
-            if (!isContainsKeyOfDay) {
+            if (isContainsKeyOfDay) {
+                // Map key 값에 day 가 존재할 시, 해당 day 의 key 값의 value 를 불러와 +1
+                countTodoPerDayMap.replace(day, countTodoPerDayMap.get(day), countTodoPerDayMap.get(day) + 1L);
+            } else {
                 // Map key 값에 day 가 없을 시, 새로운 K, V 추가
                 countTodoPerDayMap.put(day, 1L);
-            } else {
-                // Map key 값에 day 가 존재할 시, 해당 day 의 key 값의 value 를 불러와 +1
-                countTodoPerDayMap.put(day, countTodoPerDayMap.get(day) + 1L);
             }
+        }
 
-            count = countTodoPerDayMap.get(day);
+        // Map k, v 뽑아서 dto 변환 후, 응답 dtoList 추가
+        for (Map.Entry<Long, Long> val : countTodoPerDayMap.entrySet()) {
+            Long day = val.getKey();
+            Long count = val.getValue();
             calendarDtoList.add(CalendarDto.toCalendar(day, count));
         }
 
@@ -114,19 +119,22 @@ public class MainService {
 
         for (Todo todo : todoList) {
             Long day = todo.getTodoDay();
-            Long count;
             boolean isContainsKeyOfDay = countTodoPerDayMap.containsKey(day);
 
             // Map 의 key 값에 day 가 존재하는 지에 따라 구분
-            if (!isContainsKeyOfDay) {
+            if (isContainsKeyOfDay) {
+                // Map key 값에 day 가 존재할 시, 해당 day 의 key 값의 value 를 불러와 +1
+                countTodoPerDayMap.replace(day, countTodoPerDayMap.get(day), countTodoPerDayMap.get(day) + 1L);
+            } else {
                 // Map key 값에 day 가 없을 시, 새로운 K, V 추가
                 countTodoPerDayMap.put(day, 1L);
-            } else {
-                // Map key 값에 day 가 존재할 시, 해당 day 의 key 값의 value 를 불러와 +1
-                countTodoPerDayMap.put(day, countTodoPerDayMap.get(day) + 1L);
             }
+        }
 
-            count = countTodoPerDayMap.get(day);
+        // Map k, v 뽑아서 dto 변환 후, 응답 dtoList 추가
+        for (Map.Entry<Long, Long> val : countTodoPerDayMap.entrySet()) {
+            Long day = val.getKey();
+            Long count = val.getValue();
             calendarDtoList.add(CalendarDto.toCalendar(day, count));
         }
 


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
메인 페이지 조회 시 달력 내 할 일의 요일과 개수가 출력되지 않는 오류 발생

## 작업사항
- 스프링 부트의 타임존을 한국 시간으로 설정
- 달력 내 할 일의 요일과 개수를 세는 Map 서비스 로직 수정

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #104 

## 스크린샷
### 메인 페이지 조회
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/105099062/213559594-0f118ce5-bf58-4d18-a11e-63e988e8361d.png">
<img width="989" alt="image" src="https://user-images.githubusercontent.com/105099062/213559632-451360bd-a5f5-4477-9ba6-ff406aced621.png">
위 2개의 사진은 메인 페이지 조회 (화면에 짤려서 2개로 분할해서 올림)

### 달력 날짜 변경 조회
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/105099062/213559771-234ccbbe-9b0a-4c62-94bb-2f41ffe6abe2.png">

