### PR TITLE
🐛 Fix: 메인 페이지 조회 시 카테고리 색상이 null인 오류

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
+++ b/src/main/java/com/hanghae/bulletbox/diary/service/MainService.java
@@ -49,8 +49,9 @@ public class MainService {
 
             Long categoryId = category.getCategoryId();
             String categoryName = category.getCategoryName();
+            String categoryColor = category.getCategoryColor();
 
-            categoryDtoList.add(CategoryDto.toCategoryDto(categoryId, categoryName));
+            categoryDtoList.add(CategoryDto.toCategoryDto(categoryId, categoryName, categoryColor));
         }
 
         // daily 정보 가져오기


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
메인 페이지 조회 API의 서비스 로직에서 categoryColor를 응답Dto에 추가

## 작업사항
- 메인 페이지 조회 API의 서비스 로직에서 categoryColor를 응답Dto에 추가

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #111 

## 스크린샷
<img width="926" alt="image" src="https://user-images.githubusercontent.com/105099062/213743975-3f5c050d-e48b-4daa-87dd-b4a33fcc3a5c.png">

