### PR TITLE
🐛 fix: Security config에서 members get 요청 열어줌

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/hanghae/bulletbox/common/config/WebSecurityConfig.java
@@ -47,6 +47,7 @@ public class WebSecurityConfig {
                 // 로그인 인증, 인가
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/api/members/**").permitAll() // 로그인, 회원가입 uri 인증 제외
+                .antMatchers(HttpMethod.GET, "/api/members/**").permitAll() // 로그인, 회원가입 uri 인증 제외
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() // pre-flight 요청 허용
                 // swagger
                 .antMatchers("/v2/**", "/swagger**").permitAll()


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Security config에서 members get 요청 열어줌. kakao 로그인 403 에러가 Get 요청을 열어주지 않아서 발생한 것 같음.

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #245 

