### PR TITLE
🐛 Fix: 카테고리 수정 시, 카테고리의 색상만 변경될 경우 실패하는 오류 발생

### DIFF
--- a/src/main/java/com/hanghae/bulletbox/category/repository/CategoryRepository.java
+++ b/src/main/java/com/hanghae/bulletbox/category/repository/CategoryRepository.java
@@ -16,4 +16,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByCategoryIdAndMember(Long categoryId, Member member);
 
+    Optional<Category> findAllByMemberAndCategoryId(Member member, Long categoryId);
 }

--- a/src/main/java/com/hanghae/bulletbox/category/service/CategoryPageService.java
+++ b/src/main/java/com/hanghae/bulletbox/category/service/CategoryPageService.java
@@ -59,7 +59,7 @@ public class CategoryPageService {
         boolean isCategoryDuplicated = categoryService.isCategoryDuplicated(categoryDto);
 
         if (isCategoryDuplicated) {
-            throw new IllegalArgumentException(NOT_FOUND_CATEGORY_MSG.getMsg());
+            throw new IllegalArgumentException(DUPLICATE_CATEGORYNAME_MSG.getMsg());
         }
 
         // 카테고리 수정

--- a/src/main/java/com/hanghae/bulletbox/category/service/CategoryService.java
+++ b/src/main/java/com/hanghae/bulletbox/category/service/CategoryService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static com.hanghae.bulletbox.common.exception.ExceptionMessage.DUPLICATE_CATEGORYNAME_MSG;
@@ -61,6 +62,16 @@ public class CategoryService {
         MemberDto memberDto = categoryDto.getMemberDto();
         Member member = Member.toMember(memberDto);
         String categoryName = categoryDto.getCategoryName();
+        Long categoryId = categoryDto.getCategoryId();
+
+        Category category = categoryRepository.findAllByMemberAndCategoryId(member, categoryId).orElseThrow(
+                () -> new NoSuchElementException(NOT_FOUND_CATEGORY_MSG.getMsg())
+        );
+
+        // 카테고리의 색상만 변경할 경우, 기존의 카테고리 이름과 요청 온 카테고리 이름을 비교 -> 같으면 false 리턴
+        if (categoryName.equals(category.getCategoryName())) {
+            return false;
+        }
 
         Optional<Category> categoryOptional = categoryRepository.findAllByMemberAndCategoryName(member, categoryName);
 


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] PR 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
카테고리 수정 시, 카테고리의 색상만 변경될 경우 실패하는 오류 발생

## 작업사항
- 기존의 카테고리 이름과 요청 온 카테고리의 이름이 같다면, 카테고리의 이름 중복 검사를 통과하도록 로직 수정

## 연결 이슈 close
<!-- `close #이슈 번호`를 통해 PR 머지와 함께 이슈를 close 할 수 있습니다. -->
close #281 

## 스크린샷
<img width="883" alt="image" src="https://user-images.githubusercontent.com/105099062/217022540-6b80116f-12f8-456b-8ca8-35fb68ca8169.png">


